### PR TITLE
fix(docs): fix error in firebaseConnect example

### DIFF
--- a/docs/api/connect.md
+++ b/docs/api/connect.md
@@ -72,7 +72,7 @@ const enhance = compose(
   })
 )
 // use enhnace to pass todos list as props.todos
-const Todos = enhance(({ todos })) =>
+const Todos = enhance(({ todos }) =>
   <div>
     {JSON.stringify(todos, null, 2)}
   </div>


### PR DESCRIPTION
Remove a closing parenthesis that shouldn't be there.